### PR TITLE
fix: keyboard can't type

### DIFF
--- a/lib/src/ui/custom_text_edit.dart
+++ b/lib/src/ui/custom_text_edit.dart
@@ -309,6 +309,7 @@ class CustomTextEditState extends State<CustomTextEdit>
       return;
     }
     final config = TextInputConfiguration(
+      viewId: View.of(context).viewId,
       inputType: widget.inputType,
       inputAction: widget.inputAction,
       keyboardAppearance: widget.keyboardAppearance,


### PR DESCRIPTION
fix https://github.com/lollipopkit/flutter_server_box/issues/792

## Summary by Sourcery

Bug Fixes:
- Include viewId in TextInputConfiguration to resolve missing keyboard input issue.