### PR TITLE
Support tmux touch scrolling in alt buffer and mouse mode

### DIFF
--- a/lib/src/terminal_view.dart
+++ b/lib/src/terminal_view.dart
@@ -7,6 +7,7 @@ import 'package:xterm/src/core/buffer/cell_offset.dart';
 import 'package:xterm/src/core/input/keys.dart';
 import 'package:xterm/src/core/mouse/button.dart';
 import 'package:xterm/src/core/mouse/button_state.dart';
+import 'package:xterm/src/core/mouse/mode.dart';
 import 'package:xterm/src/terminal.dart';
 import 'package:xterm/src/ui/controller.dart';
 import 'package:xterm/src/ui/cursor_type.dart';
@@ -190,6 +191,9 @@ class TerminalView extends StatefulWidget {
 
 class TerminalViewState extends State<TerminalView>
     with TickerProviderStateMixin {
+  var _prevIsAltBuffer = false;
+  var _prevMouseMode = MouseMode.none;
+
   late FocusNode _focusNode;
 
   late final ShortcutManager _shortcutManager;
@@ -224,6 +228,9 @@ class TerminalViewState extends State<TerminalView>
     _shortcutManager = ShortcutManager(
       shortcuts: widget.shortcuts ?? defaultTerminalShortcuts,
     );
+    widget.terminal.addListener(_onTerminalStateChanged);
+    _prevIsAltBuffer = widget.terminal.isUsingAltBuffer;
+    _prevMouseMode = widget.terminal.mouseMode;
     super.initState();
     _updateCursorBlink(scheduleSetState: false);
   }
@@ -260,6 +267,12 @@ class TerminalViewState extends State<TerminalView>
         oldWidget.alwaysShowCursor != widget.alwaysShowCursor) {
       _updateCursorBlink(resetVisible: true);
     }
+    if (oldWidget.terminal != widget.terminal) {
+      oldWidget.terminal.removeListener(_onTerminalStateChanged);
+      widget.terminal.addListener(_onTerminalStateChanged);
+      _prevIsAltBuffer = widget.terminal.isUsingAltBuffer;
+      _prevMouseMode = widget.terminal.mouseMode;
+    }
     super.didUpdateWidget(oldWidget);
   }
 
@@ -279,8 +292,25 @@ class TerminalViewState extends State<TerminalView>
     textSizeNoti.dispose();
     _cursorBlinkTimer?.cancel();
     _cursorBlinkVisible.dispose();
+    widget.terminal.removeListener(_onTerminalStateChanged);
     _composingText.dispose();
     super.dispose();
+  }
+
+  bool get _shouldSuppressScroll {
+    if (widget.terminal.isUsingAltBuffer) return true;
+    final mode = widget.terminal.mouseMode;
+    return mode != MouseMode.none && mode.reportScroll;
+  }
+
+  void _onTerminalStateChanged() {
+    final isAltBuffer = widget.terminal.isUsingAltBuffer;
+    final mouseMode = widget.terminal.mouseMode;
+    if (_prevIsAltBuffer != isAltBuffer || _prevMouseMode != mouseMode) {
+      _prevIsAltBuffer = isAltBuffer;
+      _prevMouseMode = mouseMode;
+      setState(() {});
+    }
   }
 
   @override
@@ -290,7 +320,9 @@ class TerminalViewState extends State<TerminalView>
       child: Scrollable(
         key: _scrollableKey,
         controller: _scrollController,
-        physics: const ClampingScrollPhysics(),
+        physics: _shouldSuppressScroll
+            ? const NeverScrollableScrollPhysics()
+            : const ClampingScrollPhysics(),
         viewportBuilder: (context, offset) {
           return ValueListenableBuilder(
             valueListenable: textSizeNoti,

--- a/lib/src/ui/scroll_handler.dart
+++ b/lib/src/ui/scroll_handler.dart
@@ -1,11 +1,20 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:xterm/core.dart';
-import 'package:xterm/src/ui/infinite_scroll_view.dart';
 
-/// Handles scrolling gestures in the alternate screen buffer. In alternate
-/// screen buffer, the terminal don't have a scrollback buffer, instead, the
-/// scroll gestures are converted to escape sequences based on the current
-/// report mode declared by the application.
+/// Handles scrolling gestures when the terminal application declares support
+/// for mouse tracking (alt screen buffer or mouse mode with scroll reporting).
+///
+/// When the terminal is in alternate screen buffer, there is no scrollback, so
+/// scroll gestures are converted to escape sequences (mouse wheel events or
+/// arrow key simulation).
+///
+/// When the terminal is in main screen buffer but has enabled mouse scroll
+/// reporting, scroll gestures are forwarded to the application as mouse events
+/// and the inner scrollable is suppressed (via [NeverScrollableScrollPhysics]
+/// in [TerminalView]).
+///
+/// When neither condition is met, normal scrollback scrolling is used.
 class TerminalScrollGestureHandler extends StatefulWidget {
   const TerminalScrollGestureHandler({
     super.key,
@@ -38,22 +47,25 @@ class TerminalScrollGestureHandler extends StatefulWidget {
 
 class _TerminalScrollGestureHandlerState
     extends State<TerminalScrollGestureHandler> {
-  /// Whether the application is in alternate screen buffer. If false, then this
-  /// widget does nothing.
   var isAltBuffer = false;
-
-  /// The variable that tracks the line offset in last scroll event. Used to
-  /// determine how many the scroll events should be sent to the terminal.
-  var lastLineOffset = 0;
-
-  /// This variable tracks the last offset where the scroll gesture started.
-  /// Used to calculate the cell offset of the terminal mouse event.
   var lastPointerPosition = Offset.zero;
+  var _mouseMode = MouseMode.none;
+  double _accumulatedScroll = 0.0;
+  double? _lastTouchY;
+
+  /// Whether scroll events should be intercepted and forwarded to the terminal
+  /// instead of being handled by the inner scrollable.
+  bool get _shouldForwardScroll {
+    if (widget.terminal.isUsingAltBuffer) return true;
+    final mode = widget.terminal.mouseMode;
+    return mode != MouseMode.none && mode.reportScroll;
+  }
 
   @override
   void initState() {
     widget.terminal.addListener(_onTerminalUpdated);
     isAltBuffer = widget.terminal.isUsingAltBuffer;
+    _mouseMode = widget.terminal.mouseMode;
     super.initState();
   }
 
@@ -69,65 +81,108 @@ class _TerminalScrollGestureHandlerState
       oldWidget.terminal.removeListener(_onTerminalUpdated);
       widget.terminal.addListener(_onTerminalUpdated);
       isAltBuffer = widget.terminal.isUsingAltBuffer;
+      _mouseMode = widget.terminal.mouseMode;
     }
     super.didUpdateWidget(oldWidget);
   }
 
   void _onTerminalUpdated() {
-    if (isAltBuffer != widget.terminal.isUsingAltBuffer) {
-      isAltBuffer = widget.terminal.isUsingAltBuffer;
+    final newIsAltBuffer = widget.terminal.isUsingAltBuffer;
+    final newMouseMode = widget.terminal.mouseMode;
+    if (isAltBuffer != newIsAltBuffer || _mouseMode != newMouseMode) {
+      isAltBuffer = newIsAltBuffer;
+      _mouseMode = newMouseMode;
+      _accumulatedScroll = 0.0;
+      _lastTouchY = null;
       setState(() {});
     }
   }
 
-  /// Send a single scroll event to the terminal. If [simulateScroll] is true,
-  /// then if the application doesn't recognize mouse wheel events, this method
-  /// will simulate scroll events by sending up/down arrow keys.
-  void _sendScrollEvent(bool up) {
-    final position = widget.getCellOffset(lastPointerPosition);
+  /// Process a raw scroll delta from [PointerScrollEvent], accumulating
+  /// fractional scrolls and dispatching discrete scroll events per line.
+  void _handleScrollDelta(double dy, {bool fromTouch = false}) {
+    _accumulatedScroll += dy;
+    final lineHeight = widget.getLineHeight();
+    if (lineHeight <= 0) return;
 
-    final handled = widget.terminal.mouseInput(
-      up ? TerminalMouseButton.wheelUp : TerminalMouseButton.wheelDown,
-      TerminalMouseButtonState.down,
-      position,
-    );
+    // Use a larger threshold for touch to prevent overly sensitive scrolling
+    final threshold = fromTouch ? lineHeight * 3 : lineHeight;
+    final lines = (_accumulatedScroll.abs() / threshold).floor();
+    if (lines > 0) {
+      final up = _accumulatedScroll < 0;
+      for (var i = 0; i < lines; i++) {
+        _sendScrollEvent(up, fromTouch: fromTouch);
+      }
+      _accumulatedScroll -= (up ? -lines : lines) * threshold;
+    }
+  }
 
-    if (!handled && widget.simulateScroll) {
+  /// Send a single scroll event to the terminal. The event is forwarded as a
+  /// mouse wheel escape sequence. If the application doesn't recognize mouse
+  /// wheel events and [simulateScroll] is enabled, this falls back to sending
+  /// up/down arrow keys — but only when the application has NOT enabled mouse
+  /// mode (to avoid sending unintended arrow keys to apps expecting mouse
+  /// events).
+  ///
+  /// When [fromTouch] is true (touch drag on mobile), the arrow key fallback
+  /// is disabled to avoid flooding the terminal with key events during
+  /// continuous touch gestures.
+  void _sendScrollEvent(bool up, {bool fromTouch = false}) {
+    // Use center of terminal to avoid hitting status bar or other panes
+    final viewHeight = widget.terminal.viewHeight;
+    final viewWidth = widget.terminal.viewWidth;
+    final x = (viewWidth ~/ 2) + 1;
+    final y = (viewHeight ~/ 2) + 1;
+    final mode = widget.terminal.mouseMode;
+
+    if (mode != MouseMode.none) {
+      // Send SGR mouse wheel press + release pair with correct button IDs:
+      // wheel up = 64, wheel down = 65
+      final pb = up ? 65 : 64;
+      final onOutput = widget.terminal.onOutput;
+      if (onOutput != null) {
+        onOutput('\x1b[<$pb;$x;${y}M');
+        onOutput('\x1b[<$pb;$x;${y}m');
+      }
+    } else if (!fromTouch && widget.simulateScroll) {
       widget.terminal.keyInput(
         up ? TerminalKey.arrowUp : TerminalKey.arrowDown,
       );
     }
   }
 
-  void _onScroll(double offset) {
-    final currentLineOffset = offset ~/ widget.getLineHeight();
-
-    final delta = currentLineOffset - lastLineOffset;
-
-    for (var i = 0; i < delta.abs(); i++) {
-      _sendScrollEvent(delta < 0);
-    }
-
-    lastLineOffset = currentLineOffset;
-  }
-
   @override
   Widget build(BuildContext context) {
-    if (!isAltBuffer) {
+    if (!_shouldForwardScroll) {
       return widget.child;
     }
 
     return Listener(
       onPointerSignal: (event) {
-        lastPointerPosition = event.position;
+        if (event is PointerScrollEvent) {
+          lastPointerPosition = event.position;
+          _handleScrollDelta(event.scrollDelta.dy);
+        }
       },
       onPointerDown: (event) {
         lastPointerPosition = event.position;
+        _lastTouchY = event.position.dy;
       },
-      child: InfiniteScrollView(
-        onScroll: _onScroll,
-        child: widget.child,
-      ),
+      onPointerMove: (event) {
+        if (_lastTouchY != null) {
+          final dy = _lastTouchY! - event.position.dy;
+          lastPointerPosition = event.position;
+          _handleScrollDelta(-dy, fromTouch: true);
+          _lastTouchY = event.position.dy;
+        }
+      },
+      onPointerUp: (event) {
+        _lastTouchY = null;
+      },
+      onPointerCancel: (event) {
+        _lastTouchY = null;
+      },
+      child: widget.child,
     );
   }
 }

--- a/test/src/ui/scroll_handler_test.dart
+++ b/test/src/ui/scroll_handler_test.dart
@@ -1,0 +1,227 @@
+import 'package:test/test.dart';
+import 'package:xterm/core.dart';
+
+void main() {
+  group('Scroll forwarding conditions', () {
+    test('mouseInput generates output when in alt buffer with mouse mode', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Switch to alt buffer and enable mouse scroll tracking
+      terminal.write('\x1b[?1049h'); // alt buffer
+      terminal.write('\x1b[?1002h'); // mouse mode with reportScroll
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(outputs, isNotEmpty);
+      // Should contain mouse SGR escape sequence
+      expect(outputs.first, contains('\x1b['));
+    });
+
+    test('mouseInput generates no output when not in alt buffer and mouseMode is none', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Main buffer, no mouse mode
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(outputs, isEmpty);
+    });
+
+    test('mouseInput generates output when mouseMode has reportScroll even in main buffer', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Enable mouse mode with scroll reporting in main buffer
+      terminal.write('\x1b[?1002h'); // upDownScrollDrag
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelDown,
+        TerminalMouseButtonState.down,
+        const CellOffset(5, 3),
+      );
+
+      expect(outputs, isNotEmpty);
+    });
+
+    test('mouseInput does not generate output for wheel when mouseMode is clickOnly', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Enable click-only mouse mode (DEC 9 = X10, does not report scroll)
+      terminal.write('\x1b[?9h');
+
+      // Wheel events should not be reported in clickOnly mode
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(outputs, isEmpty);
+
+      // But clicks should still be reported
+      terminal.mouseInput(
+        TerminalMouseButton.left,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(outputs, isNotEmpty);
+    });
+  });
+
+  group('simulateScroll fallback behavior', () {
+    test('mouseInput returns false when mouseMode is none, allowing arrow key fallback', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // In alt buffer with no mouse mode
+      terminal.write('\x1b[?1049h');
+
+      // mouseInput returns false when no mouse mode is active
+      final handled = terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(handled, isFalse);
+      expect(outputs, isEmpty);
+
+      // The caller (TerminalScrollGestureHandler._sendScrollEvent) would
+      // then decide to fall back to arrow key via terminal.keyInput()
+      terminal.keyInput(TerminalKey.arrowUp);
+      expect(outputs, isNotEmpty);
+    });
+
+    test('mouseInput returns true when mouseMode is active, no arrow key fallback needed', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Enable mouse mode with scroll reporting
+      terminal.write('\x1b[?1002h');
+
+      // mouseInput handles wheel events when mouse mode is active
+      final handled = terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(handled, isTrue);
+      expect(outputs, isNotEmpty);
+
+      // Verify output is a mouse escape sequence (not an arrow key)
+      expect(outputs.first, contains('\x1b['));
+    });
+  });
+
+  group('MouseMode transitions', () {
+    test('switching from none to upDownScroll enables wheel reporting', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Initially mouse mode is none
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+      expect(outputs, isEmpty);
+
+      // Enable scroll reporting
+      terminal.write('\x1b[?1002h');
+      outputs.clear();
+
+      // Now wheel events should be reported
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+      expect(outputs, isNotEmpty);
+    });
+
+    test('switching from upDownScroll to none disables wheel reporting', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Enable scroll reporting
+      terminal.write('\x1b[?1002h');
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+      expect(outputs, isNotEmpty);
+      outputs.clear();
+
+      // Disable mouse mode
+      terminal.write('\x1b[?1002l');
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+      expect(outputs, isEmpty);
+    });
+
+    test('exiting alt buffer clears mouse mode state', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Enter alt buffer
+      terminal.write('\x1b[?1049h');
+      expect(terminal.isUsingAltBuffer, isTrue);
+
+      // Exit alt buffer  
+      terminal.write('\x1b[?1049l');
+      expect(terminal.isUsingAltBuffer, isFalse);
+    });
+  });
+
+  group('Wheel direction mapping', () {
+    test('wheelUp generates correct escape sequence', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      terminal.write('\x1b[?1002h');
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(outputs, isNotEmpty);
+      // SGR format: \x1b[<button;x;yM (M = down) or m (up)
+      expect(outputs.first, contains('M'));
+    });
+
+    test('wheelDown generates correct escape sequence', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      terminal.write('\x1b[?1002h');
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelDown,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(outputs, isNotEmpty);
+      // SGR format for wheel down
+      expect(outputs.first, contains('M'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- report touch scroll gestures as terminal mouse wheel input when the terminal is in alternate buffer or mouse scroll mode
- preserve normal viewport scrolling when mouse reporting is inactive
- add scroll handler tests for alt-buffer and mouse-mode behavior

## Why

This is required for ServerBox's tmux touch scrolling support.

In tmux and other full-screen terminal UIs such as vim, less, and htop, the terminal is commonly in the alternate buffer and expects scroll gestures to be delivered as mouse wheel input. Without this change, touch scrolling is handled as viewport scrolling instead, so tmux panes and full-screen remote apps do not scroll correctly on touch devices.

## Validation

- `flutter test test/src/ui/scroll_handler_test.dart`
