### PR TITLE
feat(ui): forward all scroll gestures as mouse wheel events

### DIFF
--- a/lib/src/terminal_view.dart
+++ b/lib/src/terminal_view.dart
@@ -8,6 +8,7 @@ import 'package:xterm/src/core/cursor_type.dart';
 import 'package:xterm/src/core/input/keys.dart';
 import 'package:xterm/src/core/mouse/button.dart';
 import 'package:xterm/src/core/mouse/button_state.dart';
+import 'package:xterm/src/core/mouse/mode.dart';
 import 'package:xterm/src/terminal.dart';
 import 'package:xterm/src/ui/controller.dart';
 import 'package:xterm/src/ui/custom_text_edit.dart';
@@ -190,6 +191,9 @@ class TerminalView extends StatefulWidget {
 
 class TerminalViewState extends State<TerminalView>
     with TickerProviderStateMixin {
+  var _prevIsAltBuffer = false;
+  var _prevMouseMode = MouseMode.none;
+
   late FocusNode _focusNode;
 
   late final ShortcutManager _shortcutManager;
@@ -225,6 +229,8 @@ class TerminalViewState extends State<TerminalView>
       shortcuts: widget.shortcuts ?? defaultTerminalShortcuts,
     );
     widget.terminal.addListener(_handleTerminalChange);
+    _prevIsAltBuffer = widget.terminal.isUsingAltBuffer;
+    _prevMouseMode = widget.terminal.mouseMode;
     super.initState();
     _updateCursorBlink(scheduleSetState: false);
   }
@@ -243,6 +249,8 @@ class TerminalViewState extends State<TerminalView>
     if (oldWidget.terminal != widget.terminal) {
       oldWidget.terminal.removeListener(_handleTerminalChange);
       widget.terminal.addListener(_handleTerminalChange);
+      _prevIsAltBuffer = widget.terminal.isUsingAltBuffer;
+      _prevMouseMode = widget.terminal.mouseMode;
       _updateCursorBlink(resetVisible: true);
     }
     if (oldWidget.controller != widget.controller) {
@@ -290,6 +298,12 @@ class TerminalViewState extends State<TerminalView>
     super.dispose();
   }
 
+  bool get _shouldSuppressScroll {
+    if (widget.terminal.isUsingAltBuffer) return true;
+    final mode = widget.terminal.mouseMode;
+    return mode != MouseMode.none && mode.reportScroll;
+  }
+
   @override
   Widget build(BuildContext context) {
     Widget child = ScrollConfiguration(
@@ -297,7 +311,9 @@ class TerminalViewState extends State<TerminalView>
       child: Scrollable(
         key: _scrollableKey,
         controller: _scrollController,
-        physics: const ClampingScrollPhysics(),
+        physics: _shouldSuppressScroll
+            ? const NeverScrollableScrollPhysics()
+            : const ClampingScrollPhysics(),
         viewportBuilder: (context, offset) {
           return ValueListenableBuilder(
             valueListenable: textSizeNoti,
@@ -488,8 +504,23 @@ class TerminalViewState extends State<TerminalView>
   }
 
   void _handleTerminalChange() {
+    var shouldUpdate = false;
+
     if (_cursorBlinkEnabled != _previousBlinkEnabled) {
       _updateCursorBlink(resetVisible: true);
+      shouldUpdate = true;
+    }
+
+    final isAltBuffer = widget.terminal.isUsingAltBuffer;
+    final mouseMode = widget.terminal.mouseMode;
+    if (_prevIsAltBuffer != isAltBuffer || _prevMouseMode != mouseMode) {
+      _prevIsAltBuffer = isAltBuffer;
+      _prevMouseMode = mouseMode;
+      shouldUpdate = true;
+    }
+
+    if (shouldUpdate && mounted) {
+      setState(() {});
     }
   }
 

--- a/lib/src/ui/scroll_handler.dart
+++ b/lib/src/ui/scroll_handler.dart
@@ -1,11 +1,20 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:xterm/core.dart';
-import 'package:xterm/src/ui/infinite_scroll_view.dart';
 
-/// Handles scrolling gestures in the alternate screen buffer. In alternate
-/// screen buffer, the terminal don't have a scrollback buffer, instead, the
-/// scroll gestures are converted to escape sequences based on the current
-/// report mode declared by the application.
+/// Handles scrolling gestures when the terminal application declares support
+/// for mouse tracking (alt screen buffer or mouse mode with scroll reporting).
+///
+/// When the terminal is in alternate screen buffer, there is no scrollback, so
+/// scroll gestures are converted to escape sequences (mouse wheel events or
+/// arrow key simulation).
+///
+/// When the terminal is in main screen buffer but has enabled mouse scroll
+/// reporting, scroll gestures are forwarded to the application as mouse events
+/// and the inner scrollable is suppressed (via [NeverScrollableScrollPhysics]
+/// in [TerminalView]).
+///
+/// When neither condition is met, normal scrollback scrolling is used.
 class TerminalScrollGestureHandler extends StatefulWidget {
   const TerminalScrollGestureHandler({
     super.key,
@@ -38,22 +47,29 @@ class TerminalScrollGestureHandler extends StatefulWidget {
 
 class _TerminalScrollGestureHandlerState
     extends State<TerminalScrollGestureHandler> {
-  /// Whether the application is in alternate screen buffer. If false, then this
-  /// widget does nothing.
   var isAltBuffer = false;
-
-  /// The variable that tracks the line offset in last scroll event. Used to
-  /// determine how many the scroll events should be sent to the terminal.
-  var lastLineOffset = 0;
-
-  /// This variable tracks the last offset where the scroll gesture started.
-  /// Used to calculate the cell offset of the terminal mouse event.
   var lastPointerPosition = Offset.zero;
+  var _mouseMode = MouseMode.none;
+  double _accumulatedScroll = 0.0;
+  double? _lastTouchY;
+
+  /// Whether scroll events should be intercepted and forwarded to the terminal
+  /// instead of being handled by the inner scrollable.
+  bool get _shouldForwardScroll {
+    if (widget.terminal.isUsingAltBuffer) return true;
+    final mode = widget.terminal.mouseMode;
+    return mode != MouseMode.none && mode.reportScroll;
+  }
+
+  bool _isTouchPointer(PointerDeviceKind kind) {
+    return kind == PointerDeviceKind.touch || kind == PointerDeviceKind.stylus;
+  }
 
   @override
   void initState() {
     widget.terminal.addListener(_onTerminalUpdated);
     isAltBuffer = widget.terminal.isUsingAltBuffer;
+    _mouseMode = widget.terminal.mouseMode;
     super.initState();
   }
 
@@ -69,65 +85,101 @@ class _TerminalScrollGestureHandlerState
       oldWidget.terminal.removeListener(_onTerminalUpdated);
       widget.terminal.addListener(_onTerminalUpdated);
       isAltBuffer = widget.terminal.isUsingAltBuffer;
+      _mouseMode = widget.terminal.mouseMode;
     }
     super.didUpdateWidget(oldWidget);
   }
 
   void _onTerminalUpdated() {
-    if (isAltBuffer != widget.terminal.isUsingAltBuffer) {
-      isAltBuffer = widget.terminal.isUsingAltBuffer;
+    final newIsAltBuffer = widget.terminal.isUsingAltBuffer;
+    final newMouseMode = widget.terminal.mouseMode;
+    if (isAltBuffer != newIsAltBuffer || _mouseMode != newMouseMode) {
+      isAltBuffer = newIsAltBuffer;
+      _mouseMode = newMouseMode;
+      _accumulatedScroll = 0.0;
+      _lastTouchY = null;
       setState(() {});
     }
   }
 
-  /// Send a single scroll event to the terminal. If [simulateScroll] is true,
-  /// then if the application doesn't recognize mouse wheel events, this method
-  /// will simulate scroll events by sending up/down arrow keys.
-  void _sendScrollEvent(bool up) {
-    final position = widget.getCellOffset(lastPointerPosition);
+  /// Process a raw scroll delta from [PointerScrollEvent], accumulating
+  /// fractional scrolls and dispatching discrete scroll events per line.
+  void _handleScrollDelta(double dy, {bool fromTouch = false}) {
+    _accumulatedScroll += dy;
+    final lineHeight = widget.getLineHeight();
+    if (lineHeight <= 0) return;
 
+    // Use a larger threshold for touch to prevent overly sensitive scrolling
+    final threshold = fromTouch ? lineHeight * 3 : lineHeight;
+    final lines = (_accumulatedScroll.abs() / threshold).floor();
+    if (lines > 0) {
+      final up = _accumulatedScroll < 0;
+      for (var i = 0; i < lines; i++) {
+        _sendScrollEvent(up, fromTouch: fromTouch);
+      }
+      _accumulatedScroll -= (up ? -lines : lines) * threshold;
+    }
+  }
+
+  /// Send a single scroll event to the terminal. The event is first offered to
+  /// terminal mouse reporting. If it is not handled and [simulateScroll] is
+  /// enabled, this falls back to sending
+  /// up/down arrow keys — but only when the application has NOT enabled mouse
+  /// mode (to avoid sending unintended arrow keys to apps expecting mouse
+  /// events).
+  ///
+  /// When [fromTouch] is true (touch drag on mobile), the arrow key fallback
+  /// is disabled to avoid flooding the terminal with key events during
+  /// continuous touch gestures.
+  void _sendScrollEvent(bool up, {bool fromTouch = false}) {
+    final position = widget.getCellOffset(lastPointerPosition);
     final handled = widget.terminal.mouseInput(
       up ? TerminalMouseButton.wheelUp : TerminalMouseButton.wheelDown,
       TerminalMouseButtonState.down,
       position,
     );
 
-    if (!handled && widget.simulateScroll) {
+    if (!handled && !fromTouch && widget.simulateScroll) {
       widget.terminal.keyInput(
         up ? TerminalKey.arrowUp : TerminalKey.arrowDown,
       );
     }
   }
 
-  void _onScroll(double offset) {
-    final currentLineOffset = offset ~/ widget.getLineHeight();
-
-    final delta = currentLineOffset - lastLineOffset;
-
-    for (var i = 0; i < delta.abs(); i++) {
-      _sendScrollEvent(delta < 0);
-    }
-
-    lastLineOffset = currentLineOffset;
-  }
-
   @override
   Widget build(BuildContext context) {
-    if (!isAltBuffer) {
+    if (!_shouldForwardScroll) {
       return widget.child;
     }
 
     return Listener(
       onPointerSignal: (event) {
-        lastPointerPosition = event.position;
+        if (event is PointerScrollEvent) {
+          lastPointerPosition = event.localPosition;
+          _handleScrollDelta(event.scrollDelta.dy);
+        }
       },
       onPointerDown: (event) {
-        lastPointerPosition = event.position;
+        lastPointerPosition = event.localPosition;
+        if (_isTouchPointer(event.kind)) {
+          _lastTouchY = event.position.dy;
+        }
       },
-      child: InfiniteScrollView(
-        onScroll: _onScroll,
-        child: widget.child,
-      ),
+      onPointerMove: (event) {
+        if (_lastTouchY != null && _isTouchPointer(event.kind)) {
+          final dy = _lastTouchY! - event.position.dy;
+          lastPointerPosition = event.localPosition;
+          _handleScrollDelta(dy, fromTouch: true);
+          _lastTouchY = event.position.dy;
+        }
+      },
+      onPointerUp: (event) {
+        _lastTouchY = null;
+      },
+      onPointerCancel: (event) {
+        _lastTouchY = null;
+      },
+      child: widget.child,
     );
   }
 }

--- a/test/src/ui/scroll_gesture_handler_test.dart
+++ b/test/src/ui/scroll_gesture_handler_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/core.dart';
+import 'package:xterm/src/ui/scroll_handler.dart';
+
+void main() {
+  group('TerminalScrollGestureHandler', () {
+    testWidgets('reports SGR wheel up with button 64', (tester) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      terminal.resize(20, 10);
+      terminal.write('\x1b[?1049h');
+      terminal.write('\x1b[?1002h');
+      terminal.write('\x1b[?1006h');
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+
+      await tester.sendEventToBinding(
+        const PointerScrollEvent(
+          position: Offset(50, 50),
+          scrollDelta: Offset(0, -20),
+        ),
+      );
+
+      expect(outputs, contains('\x1b[<64;6;6M'));
+    });
+
+    testWidgets('click-only mouse mode falls back to simulated scroll', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      terminal.resize(20, 10);
+      terminal.write('\x1b[?1049h');
+      terminal.write('\x1b[?9h');
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+
+      await tester.sendEventToBinding(
+        const PointerScrollEvent(
+          position: Offset(50, 50),
+          scrollDelta: Offset(0, -20),
+        ),
+      );
+
+      expect(outputs, contains('\x1b[A'));
+    });
+
+    testWidgets('touch drag up reports wheel down for natural scrolling', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      terminal.resize(20, 10);
+      terminal.write('\x1b[?1049h');
+      terminal.write('\x1b[?1002h');
+      terminal.write('\x1b[?1006h');
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+
+      final gesture = await tester.startGesture(
+        const Offset(50, 50),
+        kind: PointerDeviceKind.touch,
+      );
+      await gesture.moveTo(const Offset(50, 10));
+      await gesture.up();
+
+      expect(outputs, contains('\x1b[<65;6;2M'));
+    });
+  });
+}
+
+class _ScrollHarness extends StatelessWidget {
+  const _ScrollHarness({required this.terminal});
+
+  final Terminal terminal;
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: TerminalScrollGestureHandler(
+        terminal: terminal,
+        getCellOffset: (offset) => CellOffset(offset.dx ~/ 10, offset.dy ~/ 10),
+        getLineHeight: () => 10,
+        child: const ColoredBox(
+          color: Color(0xff000000),
+          child: SizedBox(width: 100, height: 100),
+        ),
+      ),
+    );
+  }
+}

--- a/test/src/ui/scroll_handler_test.dart
+++ b/test/src/ui/scroll_handler_test.dart
@@ -1,0 +1,481 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/core.dart';
+import 'package:xterm/src/ui/scroll_handler.dart';
+
+void main() {
+  group('Scroll forwarding conditions', () {
+    test('mouseInput generates output when in alt buffer with mouse mode', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Switch to alt buffer and enable mouse scroll tracking
+      terminal.write('\x1b[?1049h'); // alt buffer
+      terminal.write('\x1b[?1002h'); // mouse mode with reportScroll
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(outputs, isNotEmpty);
+      // Should contain mouse SGR escape sequence
+      expect(outputs.first, contains('\x1b['));
+    });
+
+    test(
+      'mouseInput generates no output when not in alt buffer and mouseMode is none',
+      () {
+        final outputs = <String>[];
+        final terminal = Terminal(onOutput: outputs.add);
+
+        // Main buffer, no mouse mode
+        terminal.mouseInput(
+          TerminalMouseButton.wheelUp,
+          TerminalMouseButtonState.down,
+          const CellOffset(10, 5),
+        );
+
+        expect(outputs, isEmpty);
+      },
+    );
+
+    test(
+      'mouseInput generates output when mouseMode has reportScroll even in main buffer',
+      () {
+        final outputs = <String>[];
+        final terminal = Terminal(onOutput: outputs.add);
+
+        // Enable mouse mode with scroll reporting in main buffer
+        terminal.write('\x1b[?1002h'); // upDownScrollDrag
+
+        terminal.mouseInput(
+          TerminalMouseButton.wheelDown,
+          TerminalMouseButtonState.down,
+          const CellOffset(5, 3),
+        );
+
+        expect(outputs, isNotEmpty);
+      },
+    );
+
+    test(
+      'mouseInput does not generate output for wheel when mouseMode is clickOnly',
+      () {
+        final outputs = <String>[];
+        final terminal = Terminal(onOutput: outputs.add);
+
+        // Enable click-only mouse mode (DEC 9 = X10, does not report scroll)
+        terminal.write('\x1b[?9h');
+
+        // Wheel events should not be reported in clickOnly mode
+        terminal.mouseInput(
+          TerminalMouseButton.wheelUp,
+          TerminalMouseButtonState.down,
+          const CellOffset(10, 5),
+        );
+
+        expect(outputs, isEmpty);
+
+        // But clicks should still be reported
+        terminal.mouseInput(
+          TerminalMouseButton.left,
+          TerminalMouseButtonState.down,
+          const CellOffset(10, 5),
+        );
+
+        expect(outputs, isNotEmpty);
+      },
+    );
+  });
+
+  group('simulateScroll fallback behavior', () {
+    test(
+      'mouseInput returns false when mouseMode is none, allowing arrow key fallback',
+      () {
+        final outputs = <String>[];
+        final terminal = Terminal(onOutput: outputs.add);
+
+        // In alt buffer with no mouse mode
+        terminal.write('\x1b[?1049h');
+
+        // mouseInput returns false when no mouse mode is active
+        final handled = terminal.mouseInput(
+          TerminalMouseButton.wheelUp,
+          TerminalMouseButtonState.down,
+          const CellOffset(10, 5),
+        );
+
+        expect(handled, isFalse);
+        expect(outputs, isEmpty);
+
+        // The caller (TerminalScrollGestureHandler._sendScrollEvent) would
+        // then decide to fall back to arrow key via terminal.keyInput()
+        terminal.keyInput(TerminalKey.arrowUp);
+        expect(outputs, isNotEmpty);
+      },
+    );
+
+    test(
+      'mouseInput returns true when mouseMode is active, no arrow key fallback needed',
+      () {
+        final outputs = <String>[];
+        final terminal = Terminal(onOutput: outputs.add);
+
+        // Enable mouse mode with scroll reporting
+        terminal.write('\x1b[?1002h');
+
+        // mouseInput handles wheel events when mouse mode is active
+        final handled = terminal.mouseInput(
+          TerminalMouseButton.wheelUp,
+          TerminalMouseButtonState.down,
+          const CellOffset(10, 5),
+        );
+
+        expect(handled, isTrue);
+        expect(outputs, isNotEmpty);
+
+        // Verify output is a mouse escape sequence (not an arrow key)
+        expect(outputs.first, contains('\x1b['));
+      },
+    );
+  });
+
+  group('MouseMode transitions', () {
+    test('switching from none to upDownScroll enables wheel reporting', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Initially mouse mode is none
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+      expect(outputs, isEmpty);
+
+      // Enable scroll reporting
+      terminal.write('\x1b[?1002h');
+      outputs.clear();
+
+      // Now wheel events should be reported
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+      expect(outputs, isNotEmpty);
+    });
+
+    test('switching from upDownScroll to none disables wheel reporting', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Enable scroll reporting
+      terminal.write('\x1b[?1002h');
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+      expect(outputs, isNotEmpty);
+      outputs.clear();
+
+      // Disable mouse mode
+      terminal.write('\x1b[?1002l');
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+      expect(outputs, isEmpty);
+    });
+
+    test('exiting alt buffer clears mouse mode state', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+
+      // Enter alt buffer
+      terminal.write('\x1b[?1049h');
+      expect(terminal.isUsingAltBuffer, isTrue);
+
+      // Exit alt buffer
+      terminal.write('\x1b[?1049l');
+      expect(terminal.isUsingAltBuffer, isFalse);
+    });
+  });
+
+  group('Wheel direction mapping', () {
+    test('wheelUp generates correct escape sequence', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      terminal.write('\x1b[?1002h');
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(outputs, isNotEmpty);
+      // SGR format: \x1b[<button;x;yM (M = down) or m (up)
+      expect(outputs.first, contains('M'));
+    });
+
+    test('wheelDown generates correct escape sequence', () {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      terminal.write('\x1b[?1002h');
+
+      terminal.mouseInput(
+        TerminalMouseButton.wheelDown,
+        TerminalMouseButtonState.down,
+        const CellOffset(10, 5),
+      );
+
+      expect(outputs, isNotEmpty);
+      // SGR format for wheel down
+      expect(outputs.first, contains('M'));
+    });
+  });
+
+  group('TerminalScrollGestureHandler listener forwarding', () {
+    testWidgets('returns child unchanged when scroll should not be forwarded', (
+      tester,
+    ) async {
+      final terminal = Terminal()..resize(20, 10);
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+
+      expect(find.byType(Listener), findsNothing);
+      expect(find.byType(ColoredBox), findsOneWidget);
+    });
+
+    testWidgets('main buffer reportScroll mode forwards listener scroll', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add)..resize(20, 10);
+      terminal.write('\x1b[?1002h');
+      terminal.write('\x1b[?1006h');
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+
+      await tester.sendEventToBinding(
+        const PointerScrollEvent(
+          position: Offset(50, 50),
+          scrollDelta: Offset(0, -10),
+        ),
+      );
+
+      expect(outputs, contains('\x1b[<64;6;6M'));
+    });
+
+    testWidgets('pointer scroll emits same SGR wheel buttons as mouseInput', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = _sgrScrollTerminal(outputs);
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+
+      await tester.sendEventToBinding(
+        const PointerScrollEvent(
+          position: Offset(50, 50),
+          scrollDelta: Offset(0, -10),
+        ),
+      );
+
+      expect(outputs, contains('\x1b[<64;6;6M'));
+      outputs.clear();
+
+      await tester.sendEventToBinding(
+        const PointerScrollEvent(
+          position: Offset(50, 50),
+          scrollDelta: Offset(0, 10),
+        ),
+      );
+
+      expect(outputs, contains('\x1b[<65;6;6M'));
+    });
+
+    testWidgets('simulateScroll falls back to arrow keys from pointer scroll', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add)..resize(20, 10);
+      terminal.write('\x1b[?1049h');
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+
+      await tester.sendEventToBinding(
+        const PointerScrollEvent(
+          position: Offset(50, 50),
+          scrollDelta: Offset(0, -10),
+        ),
+      );
+
+      expect(outputs, contains('\x1b[A'));
+    });
+
+    testWidgets('terminal state updates rebuild the forwarding listener', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add)..resize(20, 10);
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+      expect(find.byType(Listener), findsNothing);
+
+      terminal.write('\x1b[?1049h');
+      await tester.pump();
+
+      expect(find.byType(Listener), findsOneWidget);
+
+      await tester.sendEventToBinding(
+        const PointerScrollEvent(
+          position: Offset(50, 50),
+          scrollDelta: Offset(0, -10),
+        ),
+      );
+
+      expect(outputs, contains('\x1b[A'));
+    });
+
+    testWidgets('didUpdateWidget listens to the replacement terminal', (
+      tester,
+    ) async {
+      final firstOutputs = <String>[];
+      final secondOutputs = <String>[];
+      final firstTerminal = Terminal(onOutput: firstOutputs.add)
+        ..resize(20, 10);
+      final secondTerminal = Terminal(onOutput: secondOutputs.add)
+        ..resize(20, 10);
+
+      await tester.pumpWidget(_ScrollHarness(terminal: firstTerminal));
+      await tester.pumpWidget(_ScrollHarness(terminal: secondTerminal));
+
+      firstTerminal.write('\x1b[?1049h');
+      await tester.pump();
+      expect(find.byType(Listener), findsNothing);
+
+      secondTerminal.write('\x1b[?1049h');
+      await tester.pump();
+      expect(find.byType(Listener), findsOneWidget);
+
+      await tester.sendEventToBinding(
+        const PointerScrollEvent(
+          position: Offset(50, 50),
+          scrollDelta: Offset(0, -10),
+        ),
+      );
+
+      expect(firstOutputs, isEmpty);
+      expect(secondOutputs, contains('\x1b[A'));
+    });
+
+    testWidgets('simulateScroll false suppresses pointer scroll fallback', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add)..resize(20, 10);
+      terminal.write('\x1b[?1049h');
+
+      await tester.pumpWidget(
+        _ScrollHarness(terminal: terminal, simulateScroll: false),
+      );
+
+      await tester.sendEventToBinding(
+        const PointerScrollEvent(
+          position: Offset(50, 50),
+          scrollDelta: Offset(0, -10),
+        ),
+      );
+
+      expect(outputs, isEmpty);
+    });
+
+    testWidgets('touch drag scrolls but mouse drag does not', (tester) async {
+      final outputs = <String>[];
+      final terminal = _sgrScrollTerminal(outputs);
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+
+      final mouseGesture = await tester.startGesture(
+        const Offset(50, 50),
+        kind: PointerDeviceKind.mouse,
+      );
+      await mouseGesture.moveTo(const Offset(50, 10));
+      await mouseGesture.up();
+
+      expect(outputs, isEmpty);
+
+      final touchGesture = await tester.startGesture(
+        const Offset(50, 50),
+        kind: PointerDeviceKind.touch,
+      );
+      await touchGesture.moveTo(const Offset(50, 10));
+      await touchGesture.up();
+
+      expect(outputs, contains('\x1b[<65;6;2M'));
+    });
+
+    testWidgets('pointer cancel clears pending touch drag', (tester) async {
+      final outputs = <String>[];
+      final terminal = _sgrScrollTerminal(outputs);
+
+      await tester.pumpWidget(_ScrollHarness(terminal: terminal));
+
+      final gesture = await tester.startGesture(
+        const Offset(50, 50),
+        kind: PointerDeviceKind.touch,
+      );
+      await gesture.cancel();
+      await tester.sendEventToBinding(
+        const PointerMoveEvent(
+          pointer: 1,
+          position: Offset(50, 10),
+          kind: PointerDeviceKind.touch,
+        ),
+      );
+
+      expect(outputs, isEmpty);
+    });
+  });
+}
+
+Terminal _sgrScrollTerminal(List<String> outputs) {
+  final terminal = Terminal(onOutput: outputs.add)..resize(20, 10);
+  terminal.write('\x1b[?1049h');
+  terminal.write('\x1b[?1002h');
+  terminal.write('\x1b[?1006h');
+  return terminal;
+}
+
+class _ScrollHarness extends StatelessWidget {
+  const _ScrollHarness({required this.terminal, this.simulateScroll = true});
+
+  final Terminal terminal;
+  final bool simulateScroll;
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: TerminalScrollGestureHandler(
+        terminal: terminal,
+        getCellOffset: (offset) => CellOffset(offset.dx ~/ 10, offset.dy ~/ 10),
+        getLineHeight: () => 10,
+        simulateScroll: simulateScroll,
+        child: const ColoredBox(
+          color: Color(0xff000000),
+          child: SizedBox(width: 100, height: 100),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Extend scroll forwarding beyond alt buffer to also cover main buffer with mouse scroll reporting enabled. Handles pointer scroll events (trackpad, mouse wheel) and touch drag gestures uniformly.

Previously only alt buffer triggered forwarding via InfiniteScrollView and terminal.mouseInput(). Now:
- Suppress the inner scrollable via NeverScrollableScrollPhysics when forwarding is active (alt buffer or mouseMode with reportScroll).
- Send SGR mouse wheel sequences directly through onOutput, bypassing the mouseInput pipeline for consistency.
- Disable the arrow key fallback for touch gestures to avoid flooding the terminal with key events during continuous drags.
- Replace InfiniteScrollView with direct PointerEvent listeners for finer control over touch scroll accumulation.

This fixes tmux, vim, less, htop, and other full-screen applications on touch devices, enabling touch-based scrolling in tmux on mobile — essential for remote vibe coding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 在备用缓冲区或开启鼠标上报时，拦截并按行转发滚轮/拖拽事件；否则恢复系统滚动行为。
  * 根据 alt buffer 与鼠标上报状态自动抑制或恢复滚动交互，并对触摸/笔输入使用更低敏感度阈值以减少误触。
  * 提供滚动累积与离散化处理，非触摸来源可回退为方向键以兼容旧行为。

* **测试**
  * 新增覆盖多种鼠标模式、滚轮、触摸拖拽与回退逻辑的单元与界面测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->