### PR TITLE
fix: handle IME compose-to-commit transition on Windows

### DIFF
--- a/lib/src/ui/custom_text_edit.dart
+++ b/lib/src/ui/custom_text_edit.dart
@@ -496,7 +496,17 @@ class CustomTextEditState extends State<CustomTextEdit>
       }
     } else {
       // Generic insert/delete logic
-      if (currentText.length < previousText.length) {
+      if (!oldValue.composing.isCollapsed &&
+          _currentEditingState.composing.isCollapsed) {
+        // IME composing just ended. The committed text replaces the
+        // composing text entirely, so compute the delta from the
+        // initial (empty) state rather than from the composing text.
+        final String textDelta = currentText.substring(initTextLength);
+        if (textDelta.isNotEmpty) {
+          widget.onInsert(textDelta);
+          textChanged = true;
+        }
+      } else if (currentText.length < previousText.length) {
         // This is a simplification. For robust deletion detection without the
         // deleteDetection trick, a diff algorithm or more context is needed.
         // Assuming any reduction when not composing is a delete.

--- a/lib/src/ui/custom_text_edit.dart
+++ b/lib/src/ui/custom_text_edit.dart
@@ -453,9 +453,9 @@ class CustomTextEditState extends State<CustomTextEdit>
       return;
     }
 
+    final bool wasComposing = !oldValue.composing.isCollapsed;
     // If we were composing and now we are not, notify with null.
-    if (!oldValue.composing.isCollapsed &&
-        _currentEditingState.composing.isCollapsed) {
+    if (wasComposing) {
       widget.onComposing(null);
     }
 
@@ -463,67 +463,18 @@ class CustomTextEditState extends State<CustomTextEdit>
     final String currentText = _currentEditingState.text;
     final int initTextLength = _initEditingState.text.length;
 
-    bool textChanged = false;
-    if (widget.deleteDetection) {
-      // Specific logic for delete detection using initial placeholder characters
-      if (currentText.length < previousText.length &&
-          previousText ==
-              _initEditingState
-                  .text && // Deletion happened from the initial state
-          currentText.startsWith(
-            _initEditingState.text.substring(0, initTextLength - 1),
-          )) {
-        // Check if one char was removed
-        if (!_consumeImeDeleteSuppression()) {
-          widget.onDelete();
-          textChanged = true;
-        }
-      } else if (currentText.length > initTextLength &&
-          currentText.startsWith(_initEditingState.text)) {
-        final String textDelta = currentText.substring(initTextLength);
-        if (textDelta.isNotEmpty) {
-          widget.onInsert(textDelta);
-          textChanged = true;
-        }
-      } else if (currentText.length > previousText.length &&
-          previousText == _initEditingState.text) {
-        // Catch case where init text was empty and then text was added
-        final String textDelta = currentText.substring(initTextLength);
-        if (textDelta.isNotEmpty) {
-          widget.onInsert(textDelta);
-          textChanged = true;
-        }
-      }
-    } else {
-      // Generic insert/delete logic
-      if (!oldValue.composing.isCollapsed &&
-          _currentEditingState.composing.isCollapsed) {
-        // IME composing just ended. The committed text replaces the
-        // composing text entirely, so compute the delta from the
-        // initial (empty) state rather than from the composing text.
-        final String textDelta = currentText.substring(initTextLength);
-        if (textDelta.isNotEmpty) {
-          widget.onInsert(textDelta);
-          textChanged = true;
-        }
-      } else if (currentText.length < previousText.length) {
-        // This is a simplification. For robust deletion detection without the
-        // deleteDetection trick, a diff algorithm or more context is needed.
-        // Assuming any reduction when not composing is a delete.
-        if (!_consumeImeDeleteSuppression()) {
-          widget.onDelete();
-          textChanged = true;
-        }
-      } else if (currentText.length > previousText.length) {
-        // Assumes text is appended. More complex changes (e.g. replacing selection)
-        // are handled by setting textEditingValue directly.
-        final String textDelta = currentText.substring(previousText.length);
-        if (textDelta.isNotEmpty) {
-          widget.onInsert(textDelta);
-          textChanged = true;
-        }
-      }
-    }
+    final bool textChanged = widget.deleteDetection
+        ? _processDeleteDetectionInput(
+            previousText,
+            currentText,
+            initTextLength,
+          )
+        : _processStandardInput(
+            previousText,
+            currentText,
+            initTextLength,
+            wasComposing,
+          );
 
     // Reset editing state to the initial state if composing is done
     // and text was actually processed (either by insert/delete or composing finished).
@@ -534,6 +485,58 @@ class CustomTextEditState extends State<CustomTextEdit>
       _connection?.setEditingState(_currentEditingState);
     }
     _showCaretOnScreen();
+  }
+
+  bool _processDeleteDetectionInput(
+    String previousText,
+    String currentText,
+    int initTextLength,
+  ) {
+    final String initialText = _initEditingState.text;
+    if (currentText.length < previousText.length &&
+        previousText == initialText &&
+        currentText.startsWith(initialText.substring(0, initTextLength - 1))) {
+      if (!_consumeImeDeleteSuppression()) {
+        widget.onDelete();
+        return true;
+      }
+    } else if (currentText.length > initTextLength &&
+        currentText.startsWith(initialText)) {
+      return _insertTextDelta(currentText.substring(initTextLength));
+    } else if (currentText.length > previousText.length &&
+        previousText == initialText) {
+      return _insertTextDelta(currentText.substring(initTextLength));
+    }
+    return false;
+  }
+
+  bool _processStandardInput(
+    String previousText,
+    String currentText,
+    int initTextLength,
+    bool wasComposing,
+  ) {
+    if (wasComposing) {
+      // The committed text replaces the composing text entirely.
+      return _insertTextDelta(currentText.substring(initTextLength));
+    }
+    if (currentText.length < previousText.length) {
+      if (!_consumeImeDeleteSuppression()) {
+        widget.onDelete();
+        return true;
+      }
+    } else if (currentText.length > previousText.length) {
+      return _insertTextDelta(currentText.substring(previousText.length));
+    }
+    return false;
+  }
+
+  bool _insertTextDelta(String textDelta) {
+    if (textDelta.isEmpty) {
+      return false;
+    }
+    widget.onInsert(textDelta);
+    return true;
   }
 
   @override

--- a/test/src/ui/custom_text_edit_test.dart
+++ b/test/src/ui/custom_text_edit_test.dart
@@ -83,4 +83,66 @@ void main() {
 
     focusNode.dispose();
   });
+
+  testWidgets('IME commit inserts text when composition length changes', (
+    tester,
+  ) async {
+    final focusNode = FocusNode();
+    final insertedText = <String>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: CustomTextEdit(
+            focusNode: focusNode,
+            onInsert: insertedText.add,
+            onDelete: () {},
+            onComposing: (_) {},
+            onAction: (_) {},
+            onKeyEvent: (_, _) => KeyEventResult.ignored,
+            child: const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.pump();
+
+    final state = tester.state<CustomTextEditState>(
+      find.byType(CustomTextEdit),
+    );
+
+    state.updateEditingValue(
+      const TextEditingValue(
+        text: 'nihongo',
+        selection: TextSelection.collapsed(offset: 7),
+        composing: TextRange(start: 0, end: 7),
+      ),
+    );
+    state.updateEditingValue(
+      const TextEditingValue(
+        text: '日本語',
+        selection: TextSelection.collapsed(offset: 3),
+      ),
+    );
+
+    state.updateEditingValue(
+      const TextEditingValue(
+        text: 'ka',
+        selection: TextSelection.collapsed(offset: 2),
+        composing: TextRange(start: 0, end: 2),
+      ),
+    );
+    state.updateEditingValue(
+      const TextEditingValue(
+        text: 'かきく',
+        selection: TextSelection.collapsed(offset: 3),
+      ),
+    );
+
+    expect(insertedText, ['日本語', 'かきく']);
+
+    focusNode.dispose();
+  });
 }


### PR DESCRIPTION
## Problem

On Windows, when using an IME (e.g., Microsoft Pinyin, Sogou), text selected from the candidate window is not sent to the terminal. Direct keyboard input (Latin characters) works fine.

## Root Cause

In `custom_text_edit.dart`'s `updateEditingValue`, the generic insert/delete logic computes text deltas using `previousText.length`:

```dart
final String textDelta = currentText.substring(previousText.length);
```

When IME composing transitions from a composing state (e.g., pinyin "ni", 2 chars) to a committed state (e.g., "你", 1 char), the code sees `currentText.length (1) < previousText.length (2)` and incorrectly calls `onDelete()` instead of `onInsert()`.

If the committed text happens to be the same length as the composing text (common with some Japanese IMEs), no branch triggers at all and the text is silently dropped.

## Fix

When IME composing just ended (`oldValue` was composing, current value is not), compute the delta from `_initEditingState.text.length` (the initial empty state) rather than from the previous composing text. This correctly captures the committed text regardless of length changes between composing and committed states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of IME composition end events, ensuring committed text is processed consistently.
  * Better detection of inserted characters after composition collapses, reducing missed or misclassified input.
  * Enhanced reliability when using languages/keyboard layouts that rely on composing input, including scenarios with delete-detection enabled.
* **Tests**
  * Added a widget test covering IME commit behavior when composition length changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->